### PR TITLE
Ci

### DIFF
--- a/.github/workflows/Cabal.yml
+++ b/.github/workflows/Cabal.yml
@@ -1,59 +1,58 @@
-# modified from https://github.com/jgm/pandoc/blob/master/.github/workflows/ci.yml
 name: Cabal
 
 on:
   push:
     branches:
-    - '**'
-    paths-ignore: []
+    - 'master'
   pull_request:
-    paths-ignore: []
+    branches:
+    - 'master'
 
 jobs:
   linux:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         versions:
-          - ghc: '8.10.7'
-            cabal: '3.4'
+          - ghc: '9.10'
+            cabal: latest
     steps:
-    - uses: actions/checkout@v2
-
-    # need to install older cabal/ghc versions from ppa repository
+    - uses: actions/checkout@v4
 
     - name: Install recent cabal/ghc
-      uses: haskell/actions/setup@v1
+      id: setup
+      uses: haskell-actions/setup@v2
       with:
         ghc-version: ${{ matrix.versions.ghc }}
         cabal-version: ${{ matrix.versions.cabal }}
 
-    # declare/restore cached things
-    # caching doesn't work for scheduled runs yet
-    # https://github.com/actions/cache/issues/63
-
     - name: Cache cabal global package db
       id:   cabal-global
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cabal
-        key: ${{ runner.os }}-${{ matrix.versions.ghc }}-${{ matrix.versions.cabal }}-cabal-global-${{ hashFiles('cabal.project') }}
+        key: ${{ runner.os }}-${{ steps.setup.outputs.ghc-version }}-${{ steps.setup.outputs.cabal-version }}-cabal-global-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-${{ steps.setup.outputs.ghc-version }}-${{ steps.setup.outputs.cabal-version }}-cabal-global-
 
     - name: Cache cabal work
       id:   cabal-local
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           dist-newstyle
-        key: ${{ runner.os }}-${{ matrix.versions.ghc }}-${{ matrix.versions.cabal }}-cabal-local
+        key: ${{ runner.os }}-${{ steps.setup.outputs.ghc-version }}-${{ steps.setup.outputs.cabal-version }}-cabal-local-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-${{ steps.setup.outputs.ghc-version }}-${{ steps.setup.outputs.cabal-version }}-cabal-local-
 
-    - name: Install dependencies
+    - name: Install dependencies (OS)
       run: |
         sudo apt update
-        sudo apt install libwebkit2gtk-4.0-dev libgirepository1.0-dev
+        sudo apt install libwebkit2gtk-4.0-dev libgirepository1.0-dev libgtksourceview-3.0-dev
+
+    - name: Install dependencies (Haskell)
+      run: |
         cabal update
         cabal build all --dependencies-only --enable-tests --disable-optimization
     - name: Build

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,18 +8,22 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20240708
+# version: 0.19.20250216
 #
-# REGENDATA ("0.19.20240708",["github","cabal.project","--apt","libwebkit2gtk-4.0-dev","--apt","libgirepository1.0-dev","--apt","nodejs","--jobs-selection","any","--error-missing-methods","none","--no-install-dependencies","--installed","-Cabal"])
+# REGENDATA ("0.19.20250216",["github","cabal.project","--apt","libwebkit2gtk-4.0-dev","--apt","libgirepository1.0-dev","--apt","nodejs","--jobs-selection","any","--error-missing-methods","none","--no-install-dependencies","--installed","-Cabal"])
 #
 name: Haskell-CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:
@@ -33,9 +37,9 @@ jobs:
             compilerVersion: 9.10.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.8.2
+          - compiler: ghc-9.8.4
             compilerKind: ghc
-            compilerVersion: 9.8.2
+            compilerVersion: 9.8.4
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.6.6
@@ -80,17 +84,30 @@ jobs:
             allow-failure: false
       fail-fast: false
     steps:
-      - name: apt
+      - name: apt-get install
         run: |
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
+          apt-get install -y libgirepository1.0-dev libwebkit2gtk-4.0-dev nodejs
+      - name: Install GHCup
+        run: |
           mkdir -p "$HOME/.ghcup/bin"
           curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
-          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+      - name: Install cabal-install
+        run: |
           "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          apt-get update
-          apt-get install -y libgirepository1.0-dev libwebkit2gtk-4.0-dev nodejs
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+      - name: Install GHC (GHCup)
+        if: matrix.setup-method == 'ghcup'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -101,21 +118,12 @@ jobs:
           echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
-          HCDIR=/opt/$HCKIND/$HCVER
-          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
-          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -174,7 +182,6 @@ jobs:
           echo "packages: $GITHUB_WORKSPACE/source/jsaddle" >> cabal.project
           echo "packages: $GITHUB_WORKSPACE/source/jsaddle-warp" >> cabal.project
           echo "packages: $GITHUB_WORKSPACE/source/jsaddle-clib" >> cabal.project
-          echo "packages: $GITHUB_WORKSPACE/source/jsaddle-webkit2gtk" >> cabal.project
           cat cabal.project
       - name: sdist
         run: |
@@ -192,20 +199,17 @@ jobs:
           echo "PKGDIR_jsaddle_warp=${PKGDIR_jsaddle_warp}" >> "$GITHUB_ENV"
           PKGDIR_jsaddle_clib="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/jsaddle-clib-[0-9.]*')"
           echo "PKGDIR_jsaddle_clib=${PKGDIR_jsaddle_clib}" >> "$GITHUB_ENV"
-          PKGDIR_jsaddle_webkit2gtk="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/jsaddle-webkit2gtk-[0-9.]*')"
-          echo "PKGDIR_jsaddle_webkit2gtk=${PKGDIR_jsaddle_webkit2gtk}" >> "$GITHUB_ENV"
           rm -f cabal.project cabal.project.local
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_jsaddle}" >> cabal.project
           echo "packages: ${PKGDIR_jsaddle_warp}" >> cabal.project
           echo "packages: ${PKGDIR_jsaddle_clib}" >> cabal.project
-          echo "packages: ${PKGDIR_jsaddle_webkit2gtk}" >> cabal.project
           cat >> cabal.project <<EOF
           constraints: haskell-gi-overloading == 0.0
           allow-newer: websockets:containers
           EOF
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(Cabal|jsaddle|jsaddle-clib|jsaddle-warp|jsaddle-webkit2gtk)$/; }' >> cabal.project.local
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(Cabal|jsaddle|jsaddle-clib|jsaddle-warp)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan
@@ -235,8 +239,6 @@ jobs:
           ${CABAL} -vnormal check
           cd ${PKGDIR_jsaddle_clib} || false
           ${CABAL} -vnormal check
-          cd ${PKGDIR_jsaddle_webkit2gtk} || false
-          ${CABAL} -vnormal check
       - name: haddock
         run: |
           $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
@@ -245,8 +247,8 @@ jobs:
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
       - name: save cache
-        uses: actions/cache/save@v4
         if: always()
+        uses: actions/cache/save@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,0 +1,1 @@
+branches: master

--- a/jsaddle-clib/jsaddle-clib.cabal
+++ b/jsaddle-clib/jsaddle-clib.cabal
@@ -11,7 +11,7 @@ description:
     can be used both from GHCJS and GHC.
 category: Web, Javascript
 author: Hamish Mackenzie
-tested-with: GHC==9.10.1, GHC==9.8.2, GHC==9.6.6, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4
+tested-with: GHC==9.10.1, GHC==9.8.4, GHC==9.6.6, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4
 
 source-repository head
     type: git

--- a/jsaddle-warp/jsaddle-warp.cabal
+++ b/jsaddle-warp/jsaddle-warp.cabal
@@ -13,7 +13,7 @@ description:
     drive a small JavaScript helper.
 category: Web, Javascript
 author: Hamish Mackenzie
-tested-with: GHC==9.10.1, GHC==9.8.2, GHC==9.6.6, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4
+tested-with: GHC==9.10.1, GHC==9.8.4, GHC==9.6.6, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4
 data-files:
     node-client/index.js
     node-client/node_modules

--- a/jsaddle-webkit2gtk/jsaddle-webkit2gtk.cabal
+++ b/jsaddle-webkit2gtk/jsaddle-webkit2gtk.cabal
@@ -13,7 +13,7 @@ description:
     drive a small JavaScipt helper.
 category: Web, Javascript
 author: Hamish Mackenzie
-tested-with: GHC==9.10.1, GHC==9.8.2, GHC==9.6.6, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4
+tested-with: GHC==9.10.1, GHC==9.8.4, GHC==9.6.6, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4
 
 source-repository head
     type: git
@@ -47,4 +47,3 @@ library
     default-language: Haskell2010
     hs-source-dirs: src
     ghc-options: -ferror-spans -Wall
-

--- a/jsaddle-wkwebview/jsaddle-wkwebview.cabal
+++ b/jsaddle-wkwebview/jsaddle-wkwebview.cabal
@@ -13,7 +13,7 @@ description:
     drive a small JavaScipt helper.
 category: Web, Javascript
 author: Hamish Mackenzie
-tested-with: GHC==9.10.1, GHC==9.8.2, GHC==9.6.6, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4
+tested-with: GHC==9.10.1, GHC==9.8.4, GHC==9.6.6, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4
 
 flag include-app-delegate
     description: Include default AppDelegate C sources.

--- a/jsaddle/jsaddle.cabal
+++ b/jsaddle/jsaddle.cabal
@@ -13,7 +13,7 @@ description:
     drive a small JavaScript helper.
 category: Web, Javascript
 author: Hamish Mackenzie
-tested-with: GHC==9.10.1, GHC==9.8.2, GHC==9.6.6, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4
+tested-with: GHC==9.10.1, GHC==9.8.4, GHC==9.6.6, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4
 
 source-repository head
     type: git
@@ -46,7 +46,7 @@ library
             ghc-prim,
             http-types >=0.8.6 && <0.13,
             process >=1.2.3.0 && <1.7,
-            random >= 1.1 && < 1.3,
+            random >= 1.1 && < 1.4,
             ref-tf >=0.4.0.1 && <0.6,
             scientific >=0.3 && <0.4,
             stm >=2.4.4 && <2.6,


### PR DESCRIPTION
The hand-knitted action `Cabal.yml` fails with this error:

Failed to build gi-javascriptcore4-4.0.29. The failure occurred during the
configure step.
Build log (
/home/runner/.cabal/logs/ghc-9.10.1/gi-javascriptcore4-4.0.29-7ef6470baadeb83d82c1f20008e8502f624c7f4134d4475abf2890b2eaa32310.log
):
[1 of 2] Compiling Main             ( dist/setup/setup.hs, dist/setup/Main.o )
[2 of 2] Linking dist/setup/setup
Could not load typelib for "JavaScriptCore" version "4.0".
Error was: Typelib file for namespace 'JavaScriptCore', version '4.0' not found (0)
CallStack (from HasCallStack):
  error, called at lib/Data/GI/CodeGen/LibGIRepository.hs:109:44 in haskell-gi-0.26.14-da88d34a0a76c0159c2e8c75e11ceb4adfdb8cf0383bd830e1dc7c46e2a739d4:Data.GI.CodeGen.LibGIRepository
Error: [Cabal-7125]
Failed to build gi-javascriptcore4-4.0.29 (which is required by gi-webkit2-4.0.32 and gi-javascriptcore-4.0.29)